### PR TITLE
ログインフォーム/ギフトコード入力 の更新

### DIFF
--- a/pynanaco/core.py
+++ b/pynanaco/core.py
@@ -305,12 +305,15 @@ class PyNanaco:
             # self.current_page = MenuPage
             self.current_page = self.current_page.click_register_gift()
 
+            sleep(1)
+
+        if self.is_current(RegisterGiftPage):
             self.current_page = self.current_page.click_next()
 
             whandles = self._driver.window_handles
             self._driver.switch_to.window(whandles[1])
 
-            sleep(2)
+            sleep(1)
 
             self.current_page.input_giftcode(code)
             self.current_page = self.current_page.click_confirm()
@@ -325,12 +328,15 @@ class PyNanaco:
             except NoSuchElementException:
                 logger.error("gift code error   : " + code)
 
+            self._driver.switch_to.window(whandles[0])
+            self.current_page = RegisterGiftPage(self._driver)
+
     def logout(self):
         """
         Logout.
         """
         if self.is_current(BaseMenuPage):
-            self.current_page.click_logout()
+            self.current_page = self.current_page.click_logout()
 
         if self.is_current(AfterLogoutPage):
             logger.info("logout.")

--- a/pynanaco/core.py
+++ b/pynanaco/core.py
@@ -67,6 +67,8 @@ class PyNanaco:
 
         logger.info("login")
 
+        sleep(1)
+
         if self.is_current(MenuPage):
             self._balance_card = self.current_page.text_balance_card()
             self._balance_center = self.current_page.text_balance_center()
@@ -78,7 +80,7 @@ class PyNanaco:
         """
         :return: MenuPage
         """
-        self.current_page.input_nanaco_number(self._nanaco_number)
+        self.current_page.input_nanaco_number_upper(self._nanaco_number)
         self.current_page.input_card_number(self._card_number)
 
         return self.current_page.click_login_by_card()
@@ -87,7 +89,7 @@ class PyNanaco:
         """
         :return: MenuPage
         """
-        self.current_page.input_nanaco_number(self._nanaco_number)
+        self.current_page.input_nanaco_number_lower(self._nanaco_number)
         self.current_page.input_login_password(self._password)
 
         return self.current_page.click_login_by_password()

--- a/pynanaco/locators.py
+++ b/pynanaco/locators.py
@@ -31,7 +31,7 @@ class MenuPageLocators(BaseMenuPageLocators):
     TEXT_BALANCE_CENTER = (By.CSS_SELECTOR, '#memberInfoFull > div:nth-child(2) > div.moneyBox > div.fRight > p')
 
 
-class RegisterGiftPageLocators:
+class RegisterGiftPageLocators(BaseMenuPageLocators):
     BUTTON_NEXT = (By.CSS_SELECTOR, '#register > form > p > input[type="image"]')
 
 

--- a/pynanaco/locators.py
+++ b/pynanaco/locators.py
@@ -3,7 +3,8 @@ from selenium.webdriver.common.by import By
 
 
 class LoginPageLocators:
-    INPUT_NANACO_NUMBER = (By.NAME, 'XCID')
+    INPUT_NANACO_NUMBER_UPPER = (By.CSS_SELECTOR, '#login_card > table:nth-child(15) > tbody > tr:nth-child(1) > td.centerCell > input')
+    INPUT_NANACO_NUMBER_LOWER = (By.CSS_SELECTOR, '#login_password > table > tbody > tr:nth-child(1) > td.centerCell > input')
     INPUT_CARD_NUMBER = (By.NAME, 'SECURITY_CD')
     INPUT_LOGIN_PWD = (By.NAME, 'LOGIN_PWD')
 

--- a/pynanaco/page.py
+++ b/pynanaco/page.py
@@ -431,7 +431,7 @@ class CreditChargeErrorPage(BasePage):
         return element.text
 
 
-class RegisterGiftPage(BasePage):
+class RegisterGiftPage(BaseMenuPage):
     _locator = RegisterGiftPageLocators
 
     def click_next(self):

--- a/pynanaco/page.py
+++ b/pynanaco/page.py
@@ -40,8 +40,12 @@ class LoginPage(BasePage):
     _locator = LoginPageLocators
     _title = 'nanaco / ログイン'
 
-    def input_nanaco_number(self, nanaco_number):
-        element = self._driver.find_element(*self._locator.INPUT_NANACO_NUMBER)
+    def input_nanaco_number_upper(self, nanaco_number):
+        element = self._driver.find_element(*self._locator.INPUT_NANACO_NUMBER_UPPER)
+        element.send_keys(nanaco_number)
+
+    def input_nanaco_number_lower(self, nanaco_number):
+        element = self._driver.find_element(*self._locator.INPUT_NANACO_NUMBER_LOWER)
         element.send_keys(nanaco_number)
 
     def input_card_number(self, card_number):


### PR DESCRIPTION
下記を修正しましたので確認をお願いします。
- パスワードでのログイン時に、nanaco番号が上段のフォームに入力されてしまう点を修正
- ギフトコード入力後、操作が継続できるように現在のページを `RegisterGiftPage` に戻す
    - 複数のギフトコードを連続して登録する際に必須
- `RegisterGiftPage` を `BaseMenuPage` から継承させる